### PR TITLE
Change type of ProjectPluginConfig.DefaultValue

### DIFF
--- a/sentry/project_plugins.go
+++ b/sentry/project_plugins.go
@@ -23,7 +23,7 @@ type ProjectPluginConfig struct {
 	Placeholder  string          `json:"placeholder"`
 	Choices      json.RawMessage `json:"choices"`
 	ReadOnly     bool            `json:"readonly"`
-	DefaultValue bool            `json:"defaultValue"`
+	DefaultValue interface{}     `json:"defaultValue"`
 	Value        interface{}     `json:"value"`
 }
 


### PR DESCRIPTION
Responses from Sentry sometimes come back as bools, and sometimes come
back as strings.

I kept running into issues (`json: cannot unmarshal string into Go struct field ProjectPluginConfig.defaultValue of type bool`) while trying to create/import plugins using your excellent [terraform-sentry-provider](https://github.com/jianyuan/terraform-provider-sentry) plugin. Rebuilding that with this change fixes the issue I was seeing.