### PR TITLE
Add support for Rate Limits to Project Keys

### DIFF
--- a/sentry/project_keys.go
+++ b/sentry/project_keys.go
@@ -62,7 +62,8 @@ func (s *ProjectKeyService) List(organizationSlug string, projectSlug string) ([
 
 // CreateProjectKeyParams are the parameters for ProjectKeyService.Create.
 type CreateProjectKeyParams struct {
-	Name string `json:"name,omitempty"`
+	Name      string               `json:"name,omitempty"`
+	RateLimit *ProjectKeyRateLimit `json:"rateLimit,omitempty"`
 }
 
 // Create a new client key bound to a project.
@@ -76,7 +77,8 @@ func (s *ProjectKeyService) Create(organizationSlug string, projectSlug string, 
 
 // UpdateProjectKeyParams are the parameters for ProjectKeyService.Update.
 type UpdateProjectKeyParams struct {
-	Name string `json:"name,omitempty"`
+	Name      string               `json:"name,omitempty"`
+	RateLimit *ProjectKeyRateLimit `json:"rateLimit,omitempty"`
 }
 
 // Update a client key.

--- a/sentry/project_keys.go
+++ b/sentry/project_keys.go
@@ -72,6 +72,20 @@ func (s *ProjectKeyService) Create(organizationSlug string, projectSlug string, 
 	projectKey := new(ProjectKey)
 	apiError := new(APIError)
 	resp, err := s.sling.New().Post("projects/"+organizationSlug+"/"+projectSlug+"/keys/").BodyJSON(params).Receive(projectKey, apiError)
+
+	if err != nil {
+		return projectKey, resp, relevantError(err, *apiError)
+	}
+
+	// Hack as currently the API does not support setting rate limits on Create
+	if params.RateLimit != nil {
+		updateParams := &UpdateProjectKeyParams{
+			Name:      params.Name,
+			RateLimit: params.RateLimit,
+		}
+		projectKey, resp, err = s.Update(organizationSlug, projectSlug, projectKey.ID, updateParams)
+	}
+
 	return projectKey, resp, relevantError(err, *apiError)
 }
 

--- a/sentry/project_keys_test.go
+++ b/sentry/project_keys_test.go
@@ -147,6 +147,87 @@ func TestProjectKeyService_Create(t *testing.T) {
 	assert.Equal(t, expected, projectKey)
 }
 
+func TestProjectKeyService_Create_RateLimit(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostJSON(t, map[string]interface{}{
+			"name": "Fabulous Key",
+		}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"browserSdk": {
+				"choices": [
+					[
+						"latest",
+						"latest"
+					],
+					[
+						"4.x",
+						"4.x"
+					]
+				]
+			},
+			"browserSdkVersion": "4.x",
+			"dateCreated": "2018-09-20T15:48:07.397Z",
+			"dsn": {
+				"cdn": "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+				"csp": "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"minidump": "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"public": "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				"secret": "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				"security": "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00"
+			},
+			"id": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"isActive": true,
+			"label": "Fabulous Key",
+			"name": "Fabulous Key",
+			"projectId": 2,
+			"public": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"rateLimit": {
+				"count": 1000,
+				"window": 86400
+			},
+			"secret": "a07dcd97aa56481f82aeabaed43ca448"
+		}`)
+	})
+
+	rateLimit := ProjectKeyRateLimit{
+		Window: 86400,
+		Count:  1000,
+	}
+
+	client := NewClient(httpClient, nil, "")
+	params := &CreateProjectKeyParams{
+		Name:      "Fabulous Key",
+		RateLimit: &rateLimit,
+	}
+	projectKey, _, err := client.ProjectKeys.Create("the-interstellar-jurisdiction", "pump-station", params)
+	assert.NoError(t, err)
+	expected := &ProjectKey{
+		ID:        "cfc7b0341c6e4f6ea1a9d256a30dba00",
+		Name:      "Fabulous Key",
+		Label:     "Fabulous Key",
+		Public:    "cfc7b0341c6e4f6ea1a9d256a30dba00",
+		Secret:    "a07dcd97aa56481f82aeabaed43ca448",
+		ProjectID: 2,
+		IsActive:  true,
+		RateLimit: &rateLimit,
+		DSN: ProjectKeyDSN{
+			Secret:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+			Public:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+			CSP:      "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Security: "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Minidump: "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+			CDN:      "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+		},
+		DateCreated: mustParseTime("2018-09-20T15:48:07.397Z"),
+	}
+	assert.Equal(t, expected, projectKey)
+}
+
 func TestProjectKeyService_Update(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()

--- a/sentry/project_keys_test.go
+++ b/sentry/project_keys_test.go
@@ -1,6 +1,7 @@
 package sentry
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -155,6 +156,10 @@ func TestProjectKeyService_Create_RateLimit(t *testing.T) {
 		assertMethod(t, "POST", r)
 		assertPostJSON(t, map[string]interface{}{
 			"name": "Fabulous Key",
+			"rateLimit": map[string]interface{}{
+				"window": json.Number("86400"),
+				"count":  json.Number("1000"),
+			},
 		}, r)
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{
@@ -195,8 +200,8 @@ func TestProjectKeyService_Create_RateLimit(t *testing.T) {
 	})
 
 	rateLimit := ProjectKeyRateLimit{
-		Window: 86400,
 		Count:  1000,
+		Window: 86400,
 	}
 
 	client := NewClient(httpClient, nil, "")
@@ -286,6 +291,91 @@ func TestProjectKeyService_Update(t *testing.T) {
 		Secret:    "a07dcd97aa56481f82aeabaed43ca448",
 		ProjectID: 2,
 		IsActive:  true,
+		DSN: ProjectKeyDSN{
+			Secret:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+			Public:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+			CSP:      "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Security: "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Minidump: "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+			CDN:      "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+		},
+		DateCreated: mustParseTime("2018-09-20T15:48:07.397Z"),
+	}
+	assert.Equal(t, expected, projectKey)
+}
+
+func TestProjectKeyService_Update_RateLimit(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/befdbf32724c4ae0a3d286717b1f8127/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PUT", r)
+		assertPostJSON(t, map[string]interface{}{
+			"name": "Fabulous Key",
+			"rateLimit": map[string]interface{}{
+				"window": json.Number("86400"),
+				"count":  json.Number("1000"),
+			},
+		}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"browserSdk": {
+				"choices": [
+					[
+						"latest",
+						"latest"
+					],
+					[
+						"4.x",
+						"4.x"
+					]
+				]
+			},
+			"browserSdkVersion": "4.x",
+			"dateCreated": "2018-09-20T15:48:07.397Z",
+			"dsn": {
+				"cdn": "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+				"csp": "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"minidump": "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"public": "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				"secret": "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				"security": "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00"
+			},
+			"id": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"isActive": true,
+			"label": "Fabulous Key",
+			"name": "Fabulous Key",
+			"projectId": 2,
+			"public": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"rateLimit": {
+				"count": 1000,
+				"window": 86400
+			},
+			"secret": "a07dcd97aa56481f82aeabaed43ca448"
+		}`)
+	})
+
+	rateLimit := ProjectKeyRateLimit{
+		Count:  1000,
+		Window: 86400,
+	}
+
+	client := NewClient(httpClient, nil, "")
+	params := &UpdateProjectKeyParams{
+		Name:      "Fabulous Key",
+		RateLimit: &rateLimit,
+	}
+	projectKey, _, err := client.ProjectKeys.Update("the-interstellar-jurisdiction", "pump-station", "befdbf32724c4ae0a3d286717b1f8127", params)
+	assert.NoError(t, err)
+	expected := &ProjectKey{
+		ID:        "cfc7b0341c6e4f6ea1a9d256a30dba00",
+		Name:      "Fabulous Key",
+		Label:     "Fabulous Key",
+		Public:    "cfc7b0341c6e4f6ea1a9d256a30dba00",
+		Secret:    "a07dcd97aa56481f82aeabaed43ca448",
+		ProjectID: 2,
+		IsActive:  true,
+		RateLimit: &rateLimit,
 		DSN: ProjectKeyDSN{
 			Secret:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
 			Public:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",

--- a/sentry/project_keys_test.go
+++ b/sentry/project_keys_test.go
@@ -191,6 +191,50 @@ func TestProjectKeyService_Create_RateLimit(t *testing.T) {
 			"name": "Fabulous Key",
 			"projectId": 2,
 			"public": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"rateLimit": null,
+			"secret": "a07dcd97aa56481f82aeabaed43ca448"
+		}`)
+	})
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/cfc7b0341c6e4f6ea1a9d256a30dba00/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PUT", r)
+		assertPostJSON(t, map[string]interface{}{
+			"name": "Fabulous Key",
+			"rateLimit": map[string]interface{}{
+				"window": json.Number("86400"),
+				"count":  json.Number("1000"),
+			},
+		}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"browserSdk": {
+				"choices": [
+					[
+						"latest",
+						"latest"
+					],
+					[
+						"4.x",
+						"4.x"
+					]
+				]
+			},
+			"browserSdkVersion": "4.x",
+			"dateCreated": "2018-09-20T15:48:07.397Z",
+			"dsn": {
+				"cdn": "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+				"csp": "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"minidump": "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"public": "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				"secret": "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				"security": "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00"
+			},
+			"id": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"isActive": true,
+			"label": "Fabulous Key",
+			"name": "Fabulous Key",
+			"projectId": 2,
+			"public": "cfc7b0341c6e4f6ea1a9d256a30dba00",
 			"rateLimit": {
 				"count": 1000,
 				"window": 86400

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -61,9 +61,13 @@ func assertQuery(t *testing.T, expected map[string]string, req *http.Request) {
 // assertPostJSON tests that the Request has the expected JSON in its Body
 func assertPostJSON(t *testing.T, expected interface{}, req *http.Request) {
 	var actual interface{}
-	err := json.NewDecoder(req.Body).Decode(&actual)
+
+	d := json.NewDecoder(req.Body)
+	d.UseNumber()
+
+	err := d.Decode(&actual)
 	assert.NoError(t, err)
-	assert.Equal(t, expected, actual)
+	assert.EqualValues(t, expected, actual)
 }
 
 func mustParseTime(value string) time.Time {


### PR DESCRIPTION
Currently, rate limits are returned when reading the keys, but they can not be set when creating / updating the keys. The API supports setting rate limits during update, and I've created an issue for support during creation.

I'd like to add this so that I can manage rate limits via terraform. I'll create a PR for the terraform provider if you're happy with this one. Changes are ready to go: [Add rate limit support to terraform provider](https://github.com/jianyuan/terraform-provider-sentry/pull/33)

See here for more details on the create operation: https://github.com/getsentry/sentry/issues/12657

