### PR TITLE
Add basic rules support

### DIFF
--- a/sentry/rules.go
+++ b/sentry/rules.go
@@ -1,0 +1,106 @@
+package sentry
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dghubble/sling"
+)
+
+// Rule represents an alert rule configured for this project.
+// https://github.com/getsentry/sentry/blob/9.0.0/src/sentry/api/serializers/models/rule.py
+type Rule struct {
+	ID          string          `json:"id"`
+	ActionMatch string          `json:"actionMatch"`
+	Environment string          `json:"environment"`
+	Frequency   int             `json:"frequency"`
+	Name        string          `json:"name"`
+	Conditions  []RuleCondition `json:"conditions"`
+	Actions     []RuleAction    `json:"actions"`
+	Created     time.Time       `json:"dateCreated"`
+}
+
+// RuleCondition represents the conditions for each rule.
+// https://github.com/getsentry/sentry/blob/9.0.0/src/sentry/api/serializers/models/rule.py
+type RuleCondition struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// RuleAction represents the actions will be taken for each rule based on its conditions.
+// https://github.com/getsentry/sentry/blob/9.0.0/src/sentry/api/serializers/models/rule.py
+type RuleAction struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Tags      string `json:"tags"`
+	ChannelID string `json:"channel_id"`
+	Channel   string `json:"channel"`
+	Workspace string `json:"workspace"`
+}
+
+// ProjectKeyService provides methods for accessing Sentry project
+// client key API endpoints.
+// https://docs.sentry.io/api/projects/
+type RuleService struct {
+	sling *sling.Sling
+}
+
+func newRuleService(sling *sling.Sling) *RuleService {
+	return &RuleService{
+		sling: sling,
+	}
+}
+
+// List alert rules configured for a project.
+func (s *RuleService) List(organizationSlug string, projectSlug string) ([]Rule, *http.Response, error) {
+	rules := new([]Rule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("projects/"+organizationSlug+"/"+projectSlug+"/rules/").Receive(rules, apiError)
+	return *rules, resp, relevantError(err, *apiError)
+}
+
+// CreateRuleParams are the parameters for RuleService.Create.
+type CreateRuleParams struct {
+	ActionMatch string                       `json:"actionMatch"`
+	Environment string                       `json:"environment,omitempty"`
+	Frequency   int                          `json:"frequency"`
+	Name        string                       `json:"name"`
+	Conditions  []*CreateRuleConditionParams `json:"conditions"`
+	Actions     []*CreateRuleActionParams    `json:"actions"`
+}
+
+// CreateRuleActionParams models the actions when creating the action for the rule.
+type CreateRuleActionParams struct {
+	ID        string `json:"id"`
+	Tags      string `json:"tags"`
+	Channel   string `json:"channel"`
+	Workspace string `json:"workspace"`
+}
+
+// CreateRuleConditionParams models the conditions when creating the action for the rule.
+type CreateRuleConditionParams struct {
+	ID string `json:"id"`
+}
+
+// Create a new alert rule bound to a project.
+func (s *RuleService) Create(organizationSlug string, projectSlug string, params *CreateRuleParams) (*Rule, *http.Response, error) {
+	rule := new(Rule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("projects/"+organizationSlug+"/"+projectSlug+"/rules/").BodyJSON(params).Receive(rule, apiError)
+	return rule, resp, relevantError(err, *apiError)
+}
+
+// Update a rule.
+func (s *RuleService) Update(organizationSlug string, projectSlug string, ruleID string, params *Rule) (*Rule, *http.Response, error) {
+	rule := new(Rule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Put("projects/"+organizationSlug+"/"+projectSlug+"/rules/"+ruleID+"/").BodyJSON(params).Receive(rule, apiError)
+	return rule, resp, relevantError(err, *apiError)
+}
+
+// Delete a rule.
+func (s *RuleService) Delete(organizationSlug string, projectSlug string, ruleID string) (*http.Response, error) {
+	apiError := new(APIError)
+	resp, err := s.sling.New().Delete("projects/"+organizationSlug+"/"+projectSlug+"/rules/"+ruleID+"/").Receive(nil, apiError)
+	return resp, relevantError(err, *apiError)
+}

--- a/sentry/rules_test.go
+++ b/sentry/rules_test.go
@@ -1,0 +1,77 @@
+package sentry
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRulesService_List(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/rules/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[
+			{
+			  "environment": "production",
+			  "actionMatch": "any",
+			  "frequency": 30,
+			  "name": "Notify errors",
+			  "conditions": [
+				{
+				  "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+				  "name": "An issue is first seen"
+				}
+			  ],
+			  "id": "123456",
+			  "actions": [
+				{
+				  "name": "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+				  "tags": "environment",
+				  "channel_id": "XX00X0X0X",
+				  "workspace": "1234",
+				  "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+				  "channel": "#dummy-channel"
+				}
+			  ],
+			  "dateCreated": "2019-08-24T18:12:16.321Z"
+			}
+		]`)
+
+		client := NewClient(httpClient, nil, "")
+		rules, _, err := client.Rules.List("the-interstellar-jurisdiction", "pump-station")
+		assert.NoError(t, err)
+
+		expected := []Rule{
+			{
+				ID: "123456",
+				ActionMatch: "all",
+				Environment: "production",
+				Frequency: 30,
+				Name: "Notify errors",
+				Conditions: []RuleCondition{
+					{
+						ID: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+						Name: "An issue is first seen",
+					},
+				},
+				Actions: []RuleAction{
+					{
+						ID: "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+						Name: "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+						Tags: "environment",
+						ChannelID: "XX00X0X0X",
+						Channel: "#dummy-channel",
+						Workspace: "1234",
+					},
+				},
+				Created: mustParseTime("2019-08-24T18:12:16.321Z"),
+			},
+		}
+		assert.Equal(t, expected, rules)
+	})
+}

--- a/sentry/rules_test.go
+++ b/sentry/rules_test.go
@@ -75,3 +75,103 @@ func TestRulesService_List(t *testing.T) {
 		assert.Equal(t, expected, rules)
 	})
 }
+
+func TestRulesService_Create(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/rules/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostJSON(t, map[string]interface{}{
+			"actionMatch": "all",
+			"environment": "production",
+			"frequency": 30,
+			"name": "Notify errors",
+			"conditions": []map[string]interface{}{
+				{"ID": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+			},
+			"actions": []map[string]interface{}{
+				{
+					"ID": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					"Tags": "environment",
+					"Channel": "#dummy-channel",
+					"Workspace": "1234",
+				},
+			},
+		}, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"environment": "production",
+			"actionMatch": "any",
+			"frequency": 30,
+			"name": "Notify errors",
+			"conditions": [
+				{
+					"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					"name": "An issue is first seen"
+				}
+			],
+			"id": "123456",
+			"actions": [
+				{
+					"name": "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+					"tags": "environment",
+					"channel_id": "XX00X0X0X",
+					"workspace": "1234",
+					"id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					"channel": "#dummy-channel"
+				}
+			],
+			"dateCreated": "2019-08-24T18:12:16.321Z"
+		}`)
+
+		params := &CreateRuleParams{
+			ActionMatch: "all",
+			Environment: "production",
+			Frequency: 30,
+			Name: "Notify errors",
+			Conditions: []*CreateRuleConditionParams{
+				{ID: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+			},
+			Actions: []*CreateRuleActionParams{
+				{
+					ID: "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					Tags: "environment",
+					Channel: "#dummy-channel",
+					Workspace: "1234",
+				},
+			},
+		}
+
+		client := NewClient(httpClient, nil, "")
+		rules, _, err := client.Rules.Create("the-interstellar-jurisdiction", "pump-station", params)
+		assert.NoError(t, err)
+
+		expected := Rule{
+			ID: "123456",
+			ActionMatch: "all",
+			Environment: "production",
+			Frequency: 30,
+			Name: "Notify errors",
+			Conditions: []RuleCondition{
+				{
+					ID: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					Name: "An issue is first seen",
+				},
+			},
+			Actions: []RuleAction{
+				{
+					ID: "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					Name: "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+					Tags: "environment",
+					ChannelID: "XX00X0X0X",
+					Channel: "#dummy-channel",
+					Workspace: "1234",
+				},
+			},
+			Created: mustParseTime("2019-08-24T18:12:16.321Z"),
+		}
+		assert.Equal(t, expected, rules)
+	})
+}

--- a/sentry/rules_test.go
+++ b/sentry/rules_test.go
@@ -282,3 +282,16 @@ func TestRulesService_Update(t *testing.T) {
 		assert.Equal(t, expected, rules)
 	})
 }
+
+func TestRuleService_Delete(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/rules/12345/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	_, err := client.Rules.Delete("the-interstellar-jurisdiction", "pump-station", "12345")
+	assert.NoError(t, err)
+}

--- a/sentry/rules_test.go
+++ b/sentry/rules_test.go
@@ -175,3 +175,110 @@ func TestRulesService_Create(t *testing.T) {
 		assert.Equal(t, expected, rules)
 	})
 }
+
+func TestRulesService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/rules/12345/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		assertPostJSON(t, map[string]interface{}{
+			"actionMatch": "all",
+			"environment": "staging",
+			"frequency": 30,
+			"name": "Notify errors",
+			"conditions": []map[string]interface{}{
+				{"ID": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+			},
+			"actions": []map[string]interface{}{
+				{
+					"ID": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					"Tags": "environment",
+					"Channel": "#dummy-channel",
+					"Workspace": "1234",
+				},
+			},
+		}, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"environment": "staging",
+			"actionMatch": "any",
+			"frequency": 30,
+			"name": "Notify errors",
+			"conditions": [
+				{
+					"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					"name": "An issue is first seen"
+				}
+			],
+			"id": "123456",
+			"actions": [
+				{
+					"name": "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+					"tags": "environment",
+					"channel_id": "XX00X0X0X",
+					"workspace": "1234",
+					"id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					"channel": "#dummy-channel"
+				}
+			],
+			"dateCreated": "2019-08-24T18:12:16.321Z"
+		}`)
+
+		params := &Rule{
+			ID: "123456",
+			ActionMatch: "all",
+			Environment: "staging",
+			Frequency: 30,
+			Name: "Notify errors",
+			Conditions: []RuleCondition{
+				{
+					ID: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					Name: "An issue is first seen",
+				},
+			},
+			Actions: []RuleAction{
+				{
+					ID: "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					Name: "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+					Tags: "environment",
+					ChannelID: "XX00X0X0X",
+					Channel: "#dummy-channel",
+					Workspace: "1234",
+				},
+			},
+			Created: mustParseTime("2019-08-24T18:12:16.321Z"),
+		}
+
+		client := NewClient(httpClient, nil, "")
+		rules, _, err := client.Rules.Update("the-interstellar-jurisdiction", "pump-station", "12345", params)
+		assert.NoError(t, err)
+
+		expected := Rule{
+			ID: "123456",
+			ActionMatch: "all",
+			Environment: "production",
+			Frequency: 30,
+			Name: "Notify errors",
+			Conditions: []RuleCondition{
+				{
+					ID: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					Name: "An issue is first seen",
+				},
+			},
+			Actions: []RuleAction{
+				{
+					ID: "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+					Name: "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
+					Tags: "environment",
+					ChannelID: "XX00X0X0X",
+					Channel: "#dummy-channel",
+					Workspace: "1234",
+				},
+			},
+			Created: mustParseTime("2019-08-24T18:12:16.321Z"),
+		}
+		assert.Equal(t, expected, rules)
+	})
+}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -20,6 +20,7 @@ type Client struct {
 	Projects       *ProjectService
 	ProjectKeys    *ProjectKeyService
 	ProjectPlugins *ProjectPluginService
+	Rules          *RuleService
 }
 
 // NewClient returns a new Sentry API client.
@@ -48,6 +49,7 @@ func NewClient(httpClient *http.Client, baseURL *url.URL, token string) *Client 
 		Projects:       newProjectService(base.New()),
 		ProjectKeys:    newProjectKeyService(base.New()),
 		ProjectPlugins: newProjectPluginService(base.New()),
+		Rules:          newRuleService(base.New()),
 	}
 	return c
 }


### PR DESCRIPTION
Add basic support for creating, update and delete rules for a given project.

It currently only supports Slack notifications for now, as the payload returned is sightly different between each type of integration we would need to serialize/deserialize it into different structs.

~Also, tests are still missing (but I've opened the PR to get some early feedback).~