### PR TITLE
Add additional variables to rules

### DIFF
--- a/sentry/rules.go
+++ b/sentry/rules.go
@@ -23,8 +23,10 @@ type Rule struct {
 // RuleCondition represents the conditions for each rule.
 // https://github.com/getsentry/sentry/blob/9.0.0/src/sentry/api/serializers/models/rule.py
 type RuleCondition struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Interval string `json:"interval"`
+	Value    int    `json:"value"`
 }
 
 // RuleAction represents the actions will be taken for each rule based on its conditions.
@@ -79,7 +81,9 @@ type CreateRuleActionParams struct {
 
 // CreateRuleConditionParams models the conditions when creating the action for the rule.
 type CreateRuleConditionParams struct {
-	ID string `json:"id"`
+	ID       string `json:"id"`
+	Interval string `json:"interval"`
+	Value    int    `json:"value"`
 }
 
 // Create a new alert rule bound to a project.

--- a/sentry/rules_test.go
+++ b/sentry/rules_test.go
@@ -24,7 +24,9 @@ func TestRulesService_List(t *testing.T) {
 			  "conditions": [
 				{
 				  "id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-				  "name": "An issue is first seen"
+				  "name": "An issue is first seen",
+          "value": 500,
+          "interval": "1h"
 				}
 			  ],
 			  "id": "123456",
@@ -89,7 +91,7 @@ func TestRulesService_Create(t *testing.T) {
 			"frequency":   30,
 			"name":        "Notify errors",
 			"conditions": []map[string]interface{}{
-				{"ID": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+				{"ID": "sentry.rules.conditions.event_frequency.EventFrequencyCondition", "value": 500, "interval": "1h"},
 			},
 			"actions": []map[string]interface{}{
 				{
@@ -133,7 +135,11 @@ func TestRulesService_Create(t *testing.T) {
 			Frequency:   30,
 			Name:        "Notify errors",
 			Conditions: []*CreateRuleConditionParams{
-				{ID: "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+				{
+					ID:       "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					Value:    500,
+					Interval: "1h",
+				},
 			},
 			Actions: []*CreateRuleActionParams{
 				{
@@ -190,7 +196,7 @@ func TestRulesService_Update(t *testing.T) {
 			"frequency":   30,
 			"name":        "Notify errors",
 			"conditions": []map[string]interface{}{
-				{"ID": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"},
+				{"ID": "sentry.rules.conditions.event_frequency.EventFrequencyCondition", "value": 500, "interval": "1h"},
 			},
 			"actions": []map[string]interface{}{
 				{
@@ -237,8 +243,9 @@ func TestRulesService_Update(t *testing.T) {
 			Name:        "Notify errors",
 			Conditions: []RuleCondition{
 				{
-					ID:   "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
-					Name: "An issue is first seen",
+					ID:       "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition",
+					Value:    500,
+					Interval: "1h",
 				},
 			},
 			Actions: []RuleAction{


### PR DESCRIPTION
## Overview

Adds additional variables to rules to add support for more than just the `FirstSeenEventCondition` rule. Example:

```json
{
  "conditions": [
    {
      "id":  "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
      "value":  500,
      "interval": "1h"
    }
  ]
}
```