### PR TITLE
Team members

### DIFF
--- a/sentry/organization_users.go
+++ b/sentry/organization_users.go
@@ -1,0 +1,35 @@
+package sentry
+
+import (
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// OrganizationUser represents a Sentry organization user.
+type OrganizationUser struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// OrganizationUserService provides methods for accessing Sentry organization users
+// https://docs.sentry.io/api/organizations/get-organization-users/
+type OrganizationUserService struct {
+	sling *sling.Sling
+}
+
+func newOrganizationUserService(sling *sling.Sling) *OrganizationUserService {
+	return &OrganizationUserService{
+		sling: sling,
+	}
+}
+
+// List an organization's users
+// https://docs.sentry.io/api/organizations/get-organization-users/
+func (s *OrganizationUserService) List(organizationSlug string) ([]OrganizationUser, *http.Response, error) {
+	users := new([]OrganizationUser)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("organizations/"+organizationSlug+"/users/").Receive(users, apiError)
+	return *users, resp, relevantError(err, *apiError)
+}

--- a/sentry/organization_users_test.go
+++ b/sentry/organization_users_test.go
@@ -1,0 +1,59 @@
+package sentry
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeamMemberService_List(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/organizations/the-interstellar-jurisdiction/users/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Accept", "application/json")
+		fmt.Fprint(w, `[
+			{
+				"id": "1",
+				"name": "user1",
+				"email": "user1@example.com"
+			},
+			{
+				"id": "2",
+				"name": "user2",
+				"email": "user2@example.com"
+			},
+			{
+				"id": "3",
+				"name": "user3",
+				"email": "user3@example.com"
+			}
+		]`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	users, _, err := client.OrganizationUsers.List("the-interstellar-jurisdiction")
+	assert.NoError(t, err)
+
+	expected := []OrganizationUser{
+		{
+			ID:    "1",
+			Name:  "user1",
+			Email: "user1@example.com",
+		},
+		{
+			ID:    "2",
+			Name:  "user2",
+			Email: "user2@example.com",
+		},
+		{
+			ID:    "3",
+			Name:  "user3",
+			Email: "user3@example.com",
+		},
+	}
+	assert.Equal(t, expected, users)
+}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -17,6 +17,7 @@ type Client struct {
 	sling          *sling.Sling
 	Organizations  *OrganizationService
 	Teams          *TeamService
+	TeamMembers    *TeamMemberService
 	Projects       *ProjectService
 	ProjectKeys    *ProjectKeyService
 	ProjectPlugins *ProjectPluginService
@@ -46,6 +47,7 @@ func NewClient(httpClient *http.Client, baseURL *url.URL, token string) *Client 
 		sling:          base,
 		Organizations:  newOrganizationService(base.New()),
 		Teams:          newTeamService(base.New()),
+		TeamMembers:    newTeamMemberService(base.New()),
 		Projects:       newProjectService(base.New()),
 		ProjectKeys:    newProjectKeyService(base.New()),
 		ProjectPlugins: newProjectPluginService(base.New()),

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -14,14 +14,15 @@ const (
 )
 
 type Client struct {
-	sling          *sling.Sling
-	Organizations  *OrganizationService
-	Teams          *TeamService
-	TeamMembers    *TeamMemberService
-	Projects       *ProjectService
-	ProjectKeys    *ProjectKeyService
-	ProjectPlugins *ProjectPluginService
-	Rules          *RuleService
+	sling             *sling.Sling
+	Organizations     *OrganizationService
+	OrganizationUsers *OrganizationUserService
+	Teams             *TeamService
+	TeamMembers       *TeamMemberService
+	Projects          *ProjectService
+	ProjectKeys       *ProjectKeyService
+	ProjectPlugins    *ProjectPluginService
+	Rules             *RuleService
 }
 
 // NewClient returns a new Sentry API client.
@@ -44,14 +45,15 @@ func NewClient(httpClient *http.Client, baseURL *url.URL, token string) *Client 
 	}
 
 	c := &Client{
-		sling:          base,
-		Organizations:  newOrganizationService(base.New()),
-		Teams:          newTeamService(base.New()),
-		TeamMembers:    newTeamMemberService(base.New()),
-		Projects:       newProjectService(base.New()),
-		ProjectKeys:    newProjectKeyService(base.New()),
-		ProjectPlugins: newProjectPluginService(base.New()),
-		Rules:          newRuleService(base.New()),
+		sling:             base,
+		Organizations:     newOrganizationService(base.New()),
+		OrganizationUsers: newOrganizationUserService(base.New()),
+		Teams:             newTeamService(base.New()),
+		TeamMembers:       newTeamMemberService(base.New()),
+		Projects:          newProjectService(base.New()),
+		ProjectKeys:       newProjectKeyService(base.New()),
+		ProjectPlugins:    newProjectPluginService(base.New()),
+		Rules:             newRuleService(base.New()),
 	}
 	return c
 }

--- a/sentry/team_members.go
+++ b/sentry/team_members.go
@@ -14,7 +14,6 @@ type TeamMember struct {
 }
 
 // TeamMemberService provides methods for accessing Sentry team members
-// client key API endpoints.
 // /api/0/organizations/{organization_slug}/members/{user_id}/
 type TeamMemberService struct {
 	sling *sling.Sling

--- a/sentry/team_members.go
+++ b/sentry/team_members.go
@@ -1,0 +1,50 @@
+package sentry
+
+import (
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// TeamMember represents a Sentry team member.
+type TeamMember struct {
+	ID    string   `json:"id"`
+	Name  string   `json:"name"`
+	Teams []string `json:"teams"`
+}
+
+// TeamMemberService provides methods for accessing Sentry team members
+// client key API endpoints.
+// /api/0/organizations/{organization_slug}/members/{user_id}/
+type TeamMemberService struct {
+	sling *sling.Sling
+}
+
+func newTeamMemberService(sling *sling.Sling) *TeamMemberService {
+	return &TeamMemberService{
+		sling: sling,
+	}
+}
+
+// Get a specific team member
+// GET /api/0/organizations/{organization_slug}/members/{user_id}/
+func (s *TeamMemberService) Get(organizationSlug string, userID string) (TeamMember, *http.Response, error) {
+	member := new(TeamMember)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("organizations/"+organizationSlug+"/members/"+userID+"/").Receive(member, apiError)
+	return *member, resp, relevantError(err, *apiError)
+}
+
+// UpdateTeamMemberParams are the parameters for TeamMemberService.Update.
+type UpdateTeamMemberParams struct {
+	Teams []string `json:"teams"`
+}
+
+// Update a specific team member
+// PUT /api/0/organizations/{organization_slug}/members/{user_id}/
+func (s *TeamMemberService) Update(organizationSlug string, userID string, params *UpdateTeamMemberParams) (TeamMember, *http.Response, error) {
+	member := new(TeamMember)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Put("organizations/"+organizationSlug+"/members/"+userID+"/").BodyJSON(params).Receive(member, apiError)
+	return *member, resp, relevantError(err, *apiError)
+}

--- a/sentry/team_members_test.go
+++ b/sentry/team_members_test.go
@@ -1,0 +1,71 @@
+package sentry
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeamMemberService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/organizations/the-interstellar-jurisdiction/members/1/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Accept", "application/json")
+		fmt.Fprint(w, `{
+				"id": "1",
+				"name": "user1@example.com",
+				"teams": ["a", "b"]
+			}`,
+		)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	member, _, err := client.TeamMembers.Get("the-interstellar-jurisdiction", "1")
+	assert.NoError(t, err)
+
+	expected := TeamMember{
+		ID:    "1",
+		Name:  "user1@example.com",
+		Teams: []string{"a", "b"},
+	}
+	assert.Equal(t, expected, member)
+}
+
+func TestTeamMemberService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/organizations/the-interstellar-jurisdiction/members/1/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PUT", r)
+		assertPostJSON(t, map[string]interface{}{
+			"teams": []interface{}{"a", "b", "c"},
+		}, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Accept", "application/json")
+		fmt.Fprint(w, `{
+				"id": "1",
+				"name": "user1@example.com",
+				"teams": ["a", "b", "c"]
+			}`,
+		)
+	})
+
+	params := &UpdateTeamMemberParams{
+		Teams: []string{"a", "b", "c"},
+	}
+
+	client := NewClient(httpClient, nil, "")
+	member, _, err := client.TeamMembers.Update("the-interstellar-jurisdiction", "1", params)
+	assert.NoError(t, err)
+
+	expected := TeamMember{
+		ID:    "1",
+		Name:  "user1@example.com",
+		Teams: []string{"a", "b", "c"},
+	}
+	assert.Equal(t, expected, member)
+}


### PR DESCRIPTION
This change introduces a new service against the concept of sentry team members. It's utilizing a sentry endpoint that's not formally documented but has be in existence since 4/16/2015 per the following commit:

```
commit c1438c4c7a8e2f1bb4bdcb83e1540cef29547998
Author: David Cramer <dcramer@gmail.com>
Date:   Thu Apr 16 10:56:50 2015 -0700

    Initial work on member team edit endpoint
```

The goal of this contribution is to expose a new resource type of `sentry_team_member` on the [terraform sentry provider](https://github.com/jianyuan/terraform-provider-sentry), as well as a complementary data source `sentry_organization_user`. The idea here being that you can couple the data source with the resource with perhaps some conditional and/or set logic to manage team membership.