### PR TITLE
[Feature] Add pagination to project key service list

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/dghubble/sling v1.3.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
+	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 )

--- a/go.sum
+++ b/go.sum
@@ -8,3 +8,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
+github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=

--- a/sentry/project_keys.go
+++ b/sentry/project_keys.go
@@ -58,20 +58,24 @@ func newProjectKeyService(sling *sling.Sling) *ProjectKeyService {
 func (s *ProjectKeyService) List(organizationSlug string, projectSlug string, cursor string) ([]ProjectKey, *http.Response, error) {
 	projectKeys := new([]ProjectKey)
 	apiError := new(APIError)
-	resp, err := s.sling.New().Get("projects/"+organizationSlug+"/"+projectSlug+"/keys/" + cursor).Receive(projectKeys, apiError)
-	if resp != nil {
+
+	URL := "projects/"+organizationSlug+"/"+projectSlug+"/keys/" + cursor
+	resp, err := s.sling.New().Get(URL).Receive(projectKeys, apiError)
+	if resp != nil && resp.StatusCode == 200 {
 		linkHeaders := linkheader.Parse(resp.Header.Get("Link"))
 		// If the next Link has results query it as well
 		nextLink := linkHeaders[len(linkHeaders) - 1]
+
 		if nextLink.Param("results") == "true" {
 			c := fmt.Sprintf("?&cursor=%s", nextLink.Param("cursor"))
-			pagedProjectKeys, pagedResp, err := s.List(organizationSlug, projectSlug, c)
-			if err != nil {
-				return nil, pagedResp, relevantError(err, *apiError)
+			pagedProjectKeys, pagedResp, err2 := s.List(organizationSlug, projectSlug, c)
+			if err2 != nil {
+				return nil, pagedResp, relevantError(err2, *apiError)
 			}
 			*projectKeys = append(*projectKeys, pagedProjectKeys...)
 		}
 	}
+
 	return *projectKeys, resp, relevantError(err, *apiError)
 }
 

--- a/sentry/project_keys.go
+++ b/sentry/project_keys.go
@@ -55,7 +55,13 @@ func newProjectKeyService(sling *sling.Sling) *ProjectKeyService {
 
 // List client keys bound to a project.
 // https://docs.sentry.io/api/projects/get-project-keys/
-func (s *ProjectKeyService) List(organizationSlug string, projectSlug string, cursor string) ([]ProjectKey, *http.Response, error) {
+func (s *ProjectKeyService) List(organizationSlug string, projectSlug string) ([]ProjectKey, *http.Response, error) {
+	cursor := ""
+	return s.listPerPage(organizationSlug, projectSlug, cursor)
+}
+
+// https://docs.sentry.io/api/projects/get-project-keys/
+func (s *ProjectKeyService) listPerPage(organizationSlug string, projectSlug string, cursor string) ([]ProjectKey, *http.Response, error) {
 	projectKeys := new([]ProjectKey)
 	apiError := new(APIError)
 
@@ -68,7 +74,7 @@ func (s *ProjectKeyService) List(organizationSlug string, projectSlug string, cu
 
 		if nextLink.Param("results") == "true" {
 			c := fmt.Sprintf("?&cursor=%s", nextLink.Param("cursor"))
-			pagedProjectKeys, pagedResp, err2 := s.List(organizationSlug, projectSlug, c)
+			pagedProjectKeys, pagedResp, err2 := s.listPerPage(organizationSlug, projectSlug, c)
 			if err2 != nil {
 				return nil, pagedResp, relevantError(err2, *apiError)
 			}

--- a/sentry/project_keys_test.go
+++ b/sentry/project_keys_test.go
@@ -85,7 +85,7 @@ func TestProjectKeyService_ListWithPagination(t *testing.T) {
 	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Link", "</api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\", </api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1584513610301:0:1>; rel=\"next\"; results=\"true\"; cursor=\"1584513610301:0:1\"")
+		w.Header().Set("Link", "</api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\", </api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1234:0:1>; rel=\"next\"; results=\"true\"; cursor=\"1584513610301:0:1\"")
 		fmt.Fprint(w, `[{
 			"browserSdk": {
 				"choices": [
@@ -120,7 +120,7 @@ func TestProjectKeyService_ListWithPagination(t *testing.T) {
 		}]`)
 	})
 
-	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1584513610301:0:1", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1234:0:1", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Link", "</api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\", </api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=12:2:1>; rel=\"next\"; results=\"false\"; cursor=\"12:2:1\"")

--- a/sentry/project_keys_test.go
+++ b/sentry/project_keys_test.go
@@ -16,6 +16,7 @@ func TestProjectKeyService_List(t *testing.T) {
 	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", "</api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\", </api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1584513610301:0:1>; rel=\"next\"; results=\"false\"; cursor=\"1584513610301:0:1\"")
 		fmt.Fprint(w, `[{
 			"browserSdk": {
 				"choices": [
@@ -51,7 +52,7 @@ func TestProjectKeyService_List(t *testing.T) {
 	})
 
 	client := NewClient(httpClient, nil, "")
-	projectKeys, _, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station")
+	projectKeys, _, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station", "")
 	assert.NoError(t, err)
 
 	expected := []ProjectKey{
@@ -76,6 +77,132 @@ func TestProjectKeyService_List(t *testing.T) {
 	}
 	assert.Equal(t, expected, projectKeys)
 }
+
+func TestProjectKeyService_ListWithPagination(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", "</api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\", </api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1584513610301:0:1>; rel=\"next\"; results=\"true\"; cursor=\"1584513610301:0:1\"")
+		fmt.Fprint(w, `[{
+			"browserSdk": {
+				"choices": [
+					[
+						"latest",
+						"latest"
+					],
+					[
+						"4.x",
+						"4.x"
+					]
+				]
+			},
+			"browserSdkVersion": "4.x",
+			"dateCreated": "2018-09-20T15:48:07.397Z",
+			"dsn": {
+				"cdn": "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+				"csp": "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"minidump": "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"public": "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				"secret": "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				"security": "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00"
+			},
+			"id": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"isActive": true,
+			"label": "Fabulous Key",
+			"name": "Fabulous Key",
+			"projectId": 2,
+			"public": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"rateLimit": null,
+			"secret": "a07dcd97aa56481f82aeabaed43ca448"
+		}]`)
+	})
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=1584513610301:0:1", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Link", "</api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\", </api/0/projects/the-interstellar-jurisdiction/pump-station/keys/?&cursor=12:2:1>; rel=\"next\"; results=\"false\"; cursor=\"12:2:1\"")
+		fmt.Fprint(w, `[{
+			"browserSdk": {
+				"choices": [
+					[
+						"latest",
+						"latest"
+					],
+					[
+						"4.x",
+						"4.x"
+					]
+				]
+			},
+			"browserSdkVersion": "4.x",
+			"dateCreated": "2018-09-20T15:48:07.397Z",
+			"dsn": {
+				"cdn": "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+				"csp": "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"minidump": "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				"public": "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				"secret": "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				"security": "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00"
+			},
+			"id": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"isActive": true,
+			"label": "Fabulous Key Number 2",
+			"name": "Fabulous Key Number 2",
+			"projectId": 2,
+			"public": "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			"rateLimit": null,
+			"secret": "a07dcd97aa56481f82aeabaed43ca448"
+		}]`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	projectKeys, _, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station", "")
+	assert.NoError(t, err)
+
+	expected := []ProjectKey{
+		{
+			ID:        "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Name:      "Fabulous Key",
+			Label:     "Fabulous Key",
+			Public:    "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Secret:    "a07dcd97aa56481f82aeabaed43ca448",
+			ProjectID: 2,
+			IsActive:  true,
+			DSN: ProjectKeyDSN{
+				Secret:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				Public:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				CSP:      "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				Security: "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				Minidump: "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				CDN:      "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+			},
+			DateCreated: mustParseTime("2018-09-20T15:48:07.397Z"),
+		},
+		{
+			ID:        "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Name:      "Fabulous Key Number 2",
+			Label:     "Fabulous Key Number 2",
+			Public:    "cfc7b0341c6e4f6ea1a9d256a30dba00",
+			Secret:    "a07dcd97aa56481f82aeabaed43ca448",
+			ProjectID: 2,
+			IsActive:  true,
+			DSN: ProjectKeyDSN{
+				Secret:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00:a07dcd97aa56481f82aeabaed43ca448@sentry.io/2",
+				Public:   "https://cfc7b0341c6e4f6ea1a9d256a30dba00@sentry.io/2",
+				CSP:      "https://sentry.io/api/2/csp-report/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				Security: "https://sentry.io/api/2/security/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				Minidump: "https://sentry.io/api/2/minidump/?sentry_key=cfc7b0341c6e4f6ea1a9d256a30dba00",
+				CDN:      "https://sentry.io/js-sdk-loader/cfc7b0341c6e4f6ea1a9d256a30dba00.min.js",
+			},
+			DateCreated: mustParseTime("2018-09-20T15:48:07.397Z"),
+		},
+	}
+	assert.Equal(t, expected, projectKeys)
+}
+
 
 func TestProjectKeyService_Create(t *testing.T) {
 	httpClient, mux, server := testServer()

--- a/sentry/project_keys_test.go
+++ b/sentry/project_keys_test.go
@@ -52,7 +52,7 @@ func TestProjectKeyService_List(t *testing.T) {
 	})
 
 	client := NewClient(httpClient, nil, "")
-	projectKeys, _, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station", "")
+	projectKeys, _, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station")
 	assert.NoError(t, err)
 
 	expected := []ProjectKey{
@@ -162,7 +162,7 @@ func TestProjectKeyService_ListWithPagination(t *testing.T) {
 	// Kind of abusing the cursor field here. Normally this should always be a query of the form ?&cursor=bla but as
 	// mux.HandleFunc is somewhat stiff in mocking different results for the same path but with different queries
 	// calling the function like this allows us to mock a different response for the second page of results
-	projectKeys, _, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station", "test")
+	projectKeys, _, err := client.ProjectKeys.listPerPage("the-interstellar-jurisdiction", "pump-station", "test")
 	assert.NoError(t, err)
 
 	expected := []ProjectKey{
@@ -253,7 +253,7 @@ func TestProjectKeyService_ListWithPagination_ReturnsErrorWhenAPageIsNotPresent(
 	// Kind of abusing the cursor field here. Normally this should always be a query of the form ?&cursor=bla but as
 	// mux.HandleFunc is somewhat stiff in mocking different results for the same path but with different queries
 	// calling the function like this allows us to have the second call return a 404
-	projectKeys, resp, err := client.ProjectKeys.List("the-interstellar-jurisdiction", "pump-station", "test")
+	projectKeys, resp, err := client.ProjectKeys.listPerPage("the-interstellar-jurisdiction", "pump-station", "test")
 	assert.Equal(t, 404, resp.StatusCode)
 	assert.Error(t, err)
 


### PR DESCRIPTION
This PR makes `ProjectKeyService.List()` recursive in order to keep querying in the case of cursors with more results, as informed by the linkheader info of the response.