### PR TITLE
Team management for a project 

### DIFF
--- a/sentry/projects.go
+++ b/sentry/projects.go
@@ -164,3 +164,17 @@ func (s *ProjectService) Delete(organizationSlug string, slug string) (*http.Res
 	resp, err := s.sling.New().Delete("projects/"+organizationSlug+"/"+slug+"/").Receive(nil, apiError)
 	return resp, relevantError(err, *apiError)
 }
+
+// AddTeam add a team to a project.
+func (s *ProjectService) AddTeam(organizationSlug string, slug string, teamSlug string) (*http.Response, error) {
+	apiError := new(APIError)
+	res, err := s.sling.New().Post("projects/"+organizationSlug+"/"+slug+"/teams/"+teamSlug+"/").Receive(nil, apiError)
+	return res, relevantError(err, *apiError)
+}
+
+// RemoveTeam remove a team from a project.
+func (s *ProjectService) RemoveTeam(organizationSlug string, slug string, teamSlug string) (*http.Response, error) {
+	apiError := new(APIError)
+	res, err := s.sling.New().Delete("projects/"+organizationSlug+"/"+slug+"/teams/"+teamSlug+"/").Receive(nil, apiError)
+	return res, relevantError(err, *apiError)
+}

--- a/sentry/projects.go
+++ b/sentry/projects.go
@@ -166,10 +166,11 @@ func (s *ProjectService) Delete(organizationSlug string, slug string) (*http.Res
 }
 
 // AddTeam add a team to a project.
-func (s *ProjectService) AddTeam(organizationSlug string, slug string, teamSlug string) (*http.Response, error) {
+func (s *ProjectService) AddTeam(organizationSlug string, slug string, teamSlug string) (*Project, *http.Response, error) {
+	project := new(Project)
 	apiError := new(APIError)
-	res, err := s.sling.New().Post("projects/"+organizationSlug+"/"+slug+"/teams/"+teamSlug+"/").Receive(nil, apiError)
-	return res, relevantError(err, *apiError)
+	res, err := s.sling.New().Post("projects/"+organizationSlug+"/"+slug+"/teams/"+teamSlug+"/").Receive(project, apiError)
+	return project, res, relevantError(err, *apiError)
 }
 
 // RemoveTeam remove a team from a project.

--- a/sentry/projects_test.go
+++ b/sentry/projects_test.go
@@ -584,13 +584,31 @@ func TestProjectService_UpdateTeam(t *testing.T) {
 	httpClient, mux, server := testServer()
 	defer server.Close()
 
-	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/teams/powerful-abolitionist/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/teams/planet-express/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "POST", r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"slug": "plane-proxy",
+			"id": "5",
+			"name": "Plane Proxy",
+			"team": {
+				"id": "420",
+				"name": "Planet Express",
+				"slug": "planet-express"
+			}
+		}`)
 	})
 
 	client := NewClient(httpClient, nil, "")
-	_, err := client.Projects.AddTeam("the-interstellar-jurisdiction", "pump-station", "powerful-abolitionist")
+	project, _, err := client.Projects.AddTeam("the-interstellar-jurisdiction", "pump-station", "planet-express")
 	assert.NoError(t, err)
+	expected := &Project{
+		ID:   "5",
+		Slug: "plane-proxy",
+		Name: "Plane Proxy",
+		Team: Team{ID: "420", Slug: "planet-express", Name: "Planet Express"},
+	}
+	assert.Equal(t, expected, project)
 }
 
 func TestProjectService_DeleteTeam(t *testing.T) {

--- a/sentry/projects_test.go
+++ b/sentry/projects_test.go
@@ -579,3 +579,29 @@ func TestProjectService_Delete(t *testing.T) {
 	assert.NoError(t, err)
 
 }
+
+func TestProjectService_UpdateTeam(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/teams/powerful-abolitionist/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	_, err := client.Projects.AddTeam("the-interstellar-jurisdiction", "pump-station", "powerful-abolitionist")
+	assert.NoError(t, err)
+}
+
+func TestProjectService_DeleteTeam(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/teams/powerful-abolitionist/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	_, err := client.Projects.RemoveTeam("the-interstellar-jurisdiction", "pump-station", "powerful-abolitionist")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Team management for a project
This is the first step to fix this [Issue](https://github.com/jianyuan/terraform-provider-sentry/issues/67)

As explained in the issue Sentry seems to have changed his way to manage teams for a project. It now use those call to do so
```
POST /projects/org_slug/project_slug/teams/teams_slug
DELETE /projects/org_slug/project_slug/teams/teams_slug
```

This pr adds two functions to manage the team for a project.
