### PR TITLE
Add support for the new issue-owners feature

### DIFF
--- a/sentry/project_ownership.go
+++ b/sentry/project_ownership.go
@@ -1,0 +1,55 @@
+package sentry
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dghubble/sling"
+)
+
+// https://github.com/getsentry/sentry/blob/master/src/sentry/api/serializers/models/projectownership.py
+type ProjectOwnership struct {
+	Raw                string    `json:"raw"`
+	FallThrough        bool      `json:"fallthrough"`
+	DateCreated        time.Time `json:"dateCreated"`
+	LastUpdated        time.Time `json:"lastUpdated"`
+	IsActive           bool      `json:"isActive"`
+	AutoAssignment     bool      `json:"autoAssignment"`
+	CodeownersAutoSync *bool     `json:"codeownersAutoSync,omitempty"`
+}
+
+// ProjectOwnershipService provides methods for accessing Sentry project
+// client key API endpoints.
+type ProjectOwnershipService struct {
+	sling *sling.Sling
+}
+
+func newProjectOwnershipService(sling *sling.Sling) *ProjectOwnershipService {
+	return &ProjectOwnershipService{
+		sling: sling,
+	}
+}
+
+// Get details on a project's ownership configuration.
+func (s *ProjectOwnershipService) Get(organizationSlug string, projectSlug string) (*ProjectOwnership, *http.Response, error) {
+	project := new(ProjectOwnership)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("projects/"+organizationSlug+"/"+projectSlug+"/ownership/").Receive(project, apiError)
+	return project, resp, relevantError(err, *apiError)
+}
+
+// CreateProjectParams are the parameters for ProjectOwnershipService.Update.
+type UpdateProjectOwnershipParams struct {
+	Raw                string `json:"raw,omitempty"`
+	FallThrough        *bool  `json:"fallthrough,omitempty"`
+	AutoAssignment     *bool  `json:"autoAssignment,omitempty"`
+	CodeownersAutoSync *bool  `json:"codeownersAutoSync,omitempty"`
+}
+
+// Update a Project's Ownership configuration
+func (s *ProjectOwnershipService) Update(organizationSlug string, projectSlug string, params *UpdateProjectOwnershipParams) (*ProjectOwnership, *http.Response, error) {
+	project := new(ProjectOwnership)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Put("projects/"+organizationSlug+"/"+projectSlug+"/ownership/").BodyJSON(params).Receive(project, apiError)
+	return project, resp, relevantError(err, *apiError)
+}

--- a/sentry/project_ownership_test.go
+++ b/sentry/project_ownership_test.go
@@ -1,0 +1,83 @@
+package sentry
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectOwnershipService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/powerful-abolitionist/ownership/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"raw": "# assign issues to the product team, no matter the area\nurl:https://example.com/areas/*/*/products/* #product-team",
+			"fallthrough": false,
+			"dateCreated": "2021-11-18T13:09:16.819818Z",
+			"lastUpdated": "2022-03-01T14:00:31.317734Z",
+			"isActive": true,
+			"autoAssignment": true,
+			"codeownersAutoSync": null
+		}`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	ownership, _, err := client.Ownership.Get("the-interstellar-jurisdiction", "powerful-abolitionist")
+	assert.NoError(t, err)
+
+	expected := &ProjectOwnership{
+		Raw:                "# assign issues to the product team, no matter the area\nurl:https://example.com/areas/*/*/products/* #product-team",
+		FallThrough:        false,
+		IsActive:           true,
+		AutoAssignment:     true,
+		CodeownersAutoSync: nil,
+		DateCreated:        mustParseTime("2021-11-18T13:09:16.819818Z"),
+		LastUpdated:        mustParseTime("2022-03-01T14:00:31.317734Z"),
+	}
+
+	assert.Equal(t, expected, ownership)
+}
+
+func TestProjectOwnershipService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/the-obese-philosophers/ownership/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PUT", r)
+		assertPostJSON(t, map[string]interface{}{
+			"raw": "# assign issues to the product team, no matter the area\nurl:https://example.com/areas/*/*/products/* #product-team",
+		}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"raw": "# assign issues to the product team, no matter the area\nurl:https://example.com/areas/*/*/products/* #product-team",
+			"fallthrough": false,
+			"dateCreated": "2021-11-18T13:09:16.819818Z",
+			"lastUpdated": "2022-03-01T14:00:31.317734Z",
+			"isActive": true,
+			"autoAssignment": true,
+			"codeownersAutoSync": null
+		}`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	params := &UpdateProjectOwnershipParams{
+		Raw: "# assign issues to the product team, no matter the area\nurl:https://example.com/areas/*/*/products/* #product-team",
+	}
+	ownership, _, err := client.Ownership.Update("the-interstellar-jurisdiction", "the-obese-philosophers", params)
+	assert.NoError(t, err)
+	expected := &ProjectOwnership{
+		Raw:                "# assign issues to the product team, no matter the area\nurl:https://example.com/areas/*/*/products/* #product-team",
+		FallThrough:        false,
+		IsActive:           true,
+		AutoAssignment:     true,
+		CodeownersAutoSync: nil,
+		DateCreated:        mustParseTime("2021-11-18T13:09:16.819818Z"),
+		LastUpdated:        mustParseTime("2022-03-01T14:00:31.317734Z"),
+	}
+	assert.Equal(t, expected, ownership)
+}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -24,6 +24,7 @@ type Client struct {
 	ProjectKeys         *ProjectKeyService
 	ProjectPlugins      *ProjectPluginService
 	Rules               *RuleService
+	Ownership           *ProjectOwnershipService
 }
 
 // NewClient returns a new Sentry API client.
@@ -54,6 +55,7 @@ func NewClient(httpClient *http.Client, baseURL *url.URL, token string) *Client 
 		ProjectKeys:         newProjectKeyService(base.New()),
 		ProjectPlugins:      newProjectPluginService(base.New()),
 		Rules:               newRuleService(base.New()),
+		Ownership:           newProjectOwnershipService(base.New()),
 	}
 	return c
 }


### PR DESCRIPTION
Adds support for the Issue Owners section:

![image](https://user-images.githubusercontent.com/219090/156331868-caf76365-900b-4ddf-a8e5-37cdec56b09c.png)

Once this is accepted, I'll start on a PR to your terraform provider for sentry, as we really need to manage the issue owners section.

Thanks!