### PR TITLE
[ODC-441] Extra API fields

### DIFF
--- a/sentry/projects.go
+++ b/sentry/projects.go
@@ -58,6 +58,8 @@ type Project struct {
 
 	Team  Team   `json:"team"`
 	Teams []Team `json:"teams"`
+
+	GroupingEnhancements string `json:"groupingEnhancements"`
 }
 
 // ProjectSummary represents the summary of a Sentry project.
@@ -146,6 +148,8 @@ type UpdateProjectParams struct {
 	ResolveAge      *int                   `json:"resolveAge,omitempty"`
 	Options         map[string]interface{} `json:"options,omitempty"`
 	AllowedDomains  []string               `json:"allowedDomains,omitempty"`
+
+	GroupingEnhancements string `json:"groupingEnhancements,omitempty"`
 }
 
 // Update various attributes and configurable settings for a given project.

--- a/sentry/projects_test.go
+++ b/sentry/projects_test.go
@@ -132,6 +132,7 @@ func TestProjectService_List(t *testing.T) {
 				},
 				"platform": null,
 				"slug": "pump-station",
+				"groupingEnhancements": "pump station grouping enhancement rule",
 				"status": "active"
 			}
 		]`)
@@ -211,6 +212,8 @@ func TestProjectService_List(t *testing.T) {
 				Type: "letter_avatar",
 			},
 			Organization: expectedOrganization,
+
+			GroupingEnhancements: "pump station grouping enhancement rule",
 		},
 	}
 	assert.Equal(t, expected, projects)
@@ -355,6 +358,7 @@ func TestProjectService_Get(t *testing.T) {
 				"name": "Powerful Abolitionist",
 				"slug": "powerful-abolitionist"
 			}],
+			"groupingEnhancements": "pump-station grouping enhancement rule",
 			"verifySSL": false
 		}`)
 	})
@@ -424,6 +428,8 @@ func TestProjectService_Get(t *testing.T) {
 				Name: "Powerful Abolitionist",
 			},
 		},
+
+		GroupingEnhancements: "pump-station grouping enhancement rule",
 	}
 	assert.Equal(t, expected, project)
 }
@@ -526,6 +532,7 @@ func TestProjectService_Update(t *testing.T) {
 			"callSignReviewed": false,
 			"id": "5",
 			"subjectTemplate": "[$project] ${tag:level}: $title",
+			"groupingEnhancements": "Plane Proxy grouping enhancement rule",
 			"name": "Plane Proxy"
 		}`)
 	})
@@ -562,6 +569,8 @@ func TestProjectService_Update(t *testing.T) {
 		DigestsMaxDelay: 1800,
 		ResolveAge:      720,
 		SubjectTemplate: "[$project] ${tag:level}: $title",
+
+		GroupingEnhancements: "Plane Proxy grouping enhancement rule",
 	}
 	assert.Equal(t, expected, project)
 }

--- a/sentry/rules.go
+++ b/sentry/rules.go
@@ -70,6 +70,10 @@ type CreateRuleActionParams struct {
 	Tags      string `json:"tags"`
 	Channel   string `json:"channel"`
 	Workspace string `json:"workspace"`
+
+	Action    string `json:"action,omitempty"`
+	Service   string `json:"service,omitempty"`
+	ChannelID string `json:"channel_id,omitempty"`
 }
 
 // CreateRuleConditionParams models the conditions when creating the action for the rule.
@@ -79,6 +83,10 @@ type CreateRuleConditionParams struct {
 	Value    int    `json:"value"`
 	Level    int    `json:"level"`
 	Match    string `json:"match"`
+
+	Attribute string `json:"attribute,omitempty"`
+	Key       string `json:"key,omitempty"`
+	Name      string `json:"name"`
 }
 
 // Create a new alert rule bound to a project.
@@ -102,4 +110,14 @@ func (s *RuleService) Delete(organizationSlug string, projectSlug string, ruleID
 	apiError := new(APIError)
 	resp, err := s.sling.New().Delete("projects/"+organizationSlug+"/"+projectSlug+"/rules/"+ruleID+"/").Receive(nil, apiError)
 	return resp, relevantError(err, *apiError)
+}
+
+// Canva
+
+// Get a rule.
+func (s *RuleService) Get(organizationSlug string, projectSlug string, ruleId string) (*Rule, *http.Response, error) {
+	rule := new(Rule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("projects/"+organizationSlug+"/"+projectSlug+"/rules/"+ruleId+"/").Receive(rule, apiError)
+	return rule, resp, relevantError(err, *apiError)
 }


### PR DESCRIPTION
## 🚋 
First PR
Next PR: #2
[Related PR on the provider repo](https://github.com/Canva/terraform-provider-sentry/pull/25)

## Changes included
* #12 
* #14 
* #18 `git diff a87912f36828e42c8f71e17cb6e66c21492fbd6b 3d2ac0fd06217bd0ac4cddb5342233bccd2eb57a`

## Changes in comparison to the existing way
* Split struct fields to minimize upstream merge conflicts related to style formating.