### PR TITLE
Add functionality to create Application Performance Monitoring (APM) alerts

### DIFF
--- a/sentry/apm_rules.go
+++ b/sentry/apm_rules.go
@@ -7,9 +7,6 @@ import (
 	"github.com/dghubble/sling"
 )
 
-// RuleService provides methods for accessing Sentry project
-// client key API endpoints.
-// https://docs.sentry.io/api/projects/
 type APMRuleService struct {
 	sling *sling.Sling
 }

--- a/sentry/apm_rules.go
+++ b/sentry/apm_rules.go
@@ -1,0 +1,84 @@
+package sentry
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dghubble/sling"
+)
+
+// RuleService provides methods for accessing Sentry project
+// client key API endpoints.
+// https://docs.sentry.io/api/projects/
+type APMRuleService struct {
+	sling *sling.Sling
+}
+
+type APMRule struct {
+	ID               string    `json:"id"`
+	Name             string    `json:"name"`
+	Environment      *string   `json:"environment,omitempty"`
+	DataSet          string    `json:"dataset"`
+	Query            string    `json:"query"`
+	Aggregate        string    `json:"aggregate"`
+	TimeWindow       float64   `json:"timeWindow"`
+	ThresholdType    int       `json:"thresholdType"`
+	ResolveThreshold float64   `json:"resolveThreshold"`
+	Triggers         []Trigger `json:"triggers"`
+	Projects         []string  `json:"projects"`
+	Owner            string    `json:"owner"`
+	Created          time.Time `json:"dateCreated"`
+}
+
+type Trigger map[string]interface{}
+
+func newAPMRuleService(sling *sling.Sling) *APMRuleService {
+	return &APMRuleService{
+		sling: sling,
+	}
+}
+
+// List APM rules configured for a project
+func (s *APMRuleService) List(organizationSlug string, projectSlug string) ([]APMRule, *http.Response, error) {
+	apmRules := new([]APMRule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Get("projects/"+organizationSlug+"/"+projectSlug+"/alert-rules/").Receive(apmRules, apiError)
+	return *apmRules, resp, relevantError(err, *apiError)
+}
+
+type CreateAPMRuleParams struct {
+	Name             string    `json:"name"`
+	Environment      *string   `json:"environment,omitempty"`
+	DataSet          string    `json:"dataset"`
+	Query            string    `json:"query"`
+	Aggregate        string    `json:"aggregate"`
+	TimeWindow       float64   `json:"timeWindow"`
+	ThresholdType    int       `json:"thresholdType"`
+	ResolveThreshold float64   `json:"resolveThreshold"`
+	Triggers         []Trigger `json:"triggers"`
+	Projects         []string  `json:"projects"`
+	Owner            string    `json:"owner"`
+}
+
+// Create a new APM rule bound to a project.
+func (s *APMRuleService) Create(organizationSlug string, projectSlug string, params *CreateAPMRuleParams) (*APMRule, *http.Response, error) {
+	apmRule := new(APMRule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Post("projects/"+organizationSlug+"/"+projectSlug+"/alert-rules/").BodyJSON(params).Receive(apmRule, apiError)
+	return apmRule, resp, relevantError(err, *apiError)
+}
+
+// Update a APM rule.
+func (s *APMRuleService) Update(organizationSlug string, projectSlug string, apmRuleID string, params *APMRule) (*APMRule, *http.Response, error) {
+	apmRule := new(APMRule)
+	apiError := new(APIError)
+	resp, err := s.sling.New().Put("projects/"+organizationSlug+"/"+projectSlug+"/alert-rules/"+apmRuleID+"/").BodyJSON(params).Receive(apmRule, apiError)
+	return apmRule, resp, relevantError(err, *apiError)
+}
+
+// Delete a APM rule.
+func (s *APMRuleService) Delete(organizationSlug string, projectSlug string, apmRuleID string) (*http.Response, error) {
+	apiError := new(APIError)
+	resp, err := s.sling.New().Delete("projects/"+organizationSlug+"/"+projectSlug+"/alert-rules/"+apmRuleID+"/").Receive(nil, apiError)
+	return resp, relevantError(err, *apiError)
+}

--- a/sentry/apm_rules_test.go
+++ b/sentry/apm_rules_test.go
@@ -1,0 +1,397 @@
+package sentry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPMRuleService_List(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/alert-rules/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `[
+			{
+				"id": "12345",
+				"name": "pump-station-alert",
+				"environment": "production",
+				"dataset": "transactions",
+				"query": "http.url:http://service/unreadmessages",
+				"aggregate": "p50(transaction.duration)",
+				"thresholdType": 0,
+				"resolveThreshold": 100.0,
+				"timeWindow": 5.0,
+				"triggers": [
+					{
+						"id": "6789",
+						"alertRuleId": "12345",
+						"label": "critical",
+						"thresholdType": 0,
+						"alertThreshold": 55501.0,
+						"resolveThreshold": 100.0,
+						"dateCreated": "2022-04-07T16:46:48.607583Z",
+						"actions": [
+							{
+								"id": "12345",
+								"alertRuleTriggerId": "12345",
+								"type": "slack",
+								"targetType": "specific",
+								"targetIdentifier": "#apm-alerts",
+								"inputChannelId": "C038NF00X4F",
+								"integrationId": 123,
+								"sentryAppId": null,
+								"dateCreated": "2022-04-07T16:46:49.154638Z",
+								"desc": "Send a Slack notification to #apm-alerts"
+							}
+						]
+					}
+				],
+				"projects": [
+					"pump-station"
+				],
+				"owner": "pump-station:12345",
+				"dateCreated": "2022-04-07T16:46:48.569571Z"
+			}
+		]`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	apmRules, _, err := client.APMRules.List("the-interstellar-jurisdiction", "pump-station")
+	require.NoError(t, err)
+
+	environment := "production"
+	expected := []APMRule{
+		{
+			ID:               "12345",
+			Name:             "pump-station-alert",
+			Environment:      &environment,
+			DataSet:          "transactions",
+			Query:            "http.url:http://service/unreadmessages",
+			Aggregate:        "p50(transaction.duration)",
+			ThresholdType:    int(0),
+			ResolveThreshold: float64(100.0),
+			TimeWindow:       float64(5.0),
+			Triggers: []Trigger{
+				{
+					"id":               "6789",
+					"alertRuleId":      "12345",
+					"label":            "critical",
+					"thresholdType":    float64(0),
+					"alertThreshold":   float64(55501.0),
+					"resolveThreshold": float64(100.0),
+					"dateCreated":      "2022-04-07T16:46:48.607583Z",
+					"actions": []interface{}{map[string]interface{}{
+						"id":                 "12345",
+						"alertRuleTriggerId": "12345",
+						"type":               "slack",
+						"targetType":         "specific",
+						"targetIdentifier":   "#apm-alerts",
+						"inputChannelId":     "C038NF00X4F",
+						"integrationId":      float64(123),
+						"sentryAppId":        interface{}(nil),
+						"dateCreated":        "2022-04-07T16:46:49.154638Z",
+						"desc":               "Send a Slack notification to #apm-alerts",
+					},
+					},
+				},
+			},
+			Projects: []string{"pump-station"},
+			Owner:    "pump-station:12345",
+			Created:  mustParseTime("2022-04-07T16:46:48.569571Z"),
+		},
+	}
+	require.Equal(t, expected, apmRules)
+}
+
+func TestAPMRuleService_Create(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/alert-rules/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `
+			{
+				"id": "12345",
+				"name": "pump-station-alert",
+				"environment": "production",
+				"dataset": "transactions",
+				"query": "http.url:http://service/unreadmessages",
+				"aggregate": "p50(transaction.duration)",
+				"timeWindow": 10,
+				"thresholdType": 0,
+				"resolveThreshold": 0,
+				"triggers": [
+				  {
+					"actions": [
+					  {
+						"alertRuleTriggerId": "56789",
+						"dateCreated": "2022-04-15T15:06:01.087054Z",
+						"desc": "Send a Slack notification to #apm-alerts",
+						"id": "12389",
+						"inputChannelId": "C0XXXFKLXXX",
+						"integrationId": 111,
+						"sentryAppId": null,
+						"targetIdentifier": "#apm-alerts",
+						"targetType": "specific",
+						"type": "slack"
+					  }
+					],
+					"alertRuleId": "12345",
+					"alertThreshold": 10000,
+					"dateCreated": "2022-04-15T15:06:01.079598Z",
+					"id": "56789",
+					"label": "critical",
+					"resolveThreshold": 0,
+					"thresholdType": 0
+				  }
+				],
+				"projects": [
+				  "pump-station"
+				],
+				"owner": "pump-station:12345",
+				"dateCreated": "2022-04-15T15:06:01.05618Z"
+			}
+		`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	environment := "production"
+	params := CreateAPMRuleParams{
+		Name:             "pump-station-alert",
+		Environment:      &environment,
+		DataSet:          "transactions",
+		Query:            "http.url:http://service/unreadmessages",
+		Aggregate:        "p50(transaction.duration)",
+		TimeWindow:       10.0,
+		ThresholdType:    0,
+		ResolveThreshold: 0,
+		Triggers: []Trigger{{
+			"actions": []interface{}{map[string]interface{}{
+				"type":             "slack",
+				"targetType":       "specific",
+				"targetIdentifier": "#apm-alerts",
+				"inputChannelId":   "C0XXXFKLXXX",
+				"integrationId":    111,
+			},
+			},
+			"alertThreshold":   10000,
+			"label":            "critical",
+			"resolveThreshold": 0,
+			"thresholdType":    0,
+		}},
+		Projects: []string{"pump-station"},
+		Owner:    "pump-station:12345",
+	}
+	apmRule, _, err := client.APMRules.Create("the-interstellar-jurisdiction", "pump-station", &params)
+	require.NoError(t, err)
+
+	expected := &APMRule{
+		ID:               "12345",
+		Name:             "pump-station-alert",
+		Environment:      &environment,
+		DataSet:          "transactions",
+		Query:            "http.url:http://service/unreadmessages",
+		Aggregate:        "p50(transaction.duration)",
+		ThresholdType:    int(0),
+		ResolveThreshold: float64(0),
+		TimeWindow:       float64(10.0),
+		Triggers: []Trigger{
+			{
+				"id":               "56789",
+				"alertRuleId":      "12345",
+				"label":            "critical",
+				"thresholdType":    float64(0),
+				"alertThreshold":   float64(10000),
+				"resolveThreshold": float64(0),
+				"dateCreated":      "2022-04-15T15:06:01.079598Z",
+				"actions": []interface{}{map[string]interface{}{
+					"id":                 "12389",
+					"alertRuleTriggerId": "56789",
+					"type":               "slack",
+					"targetType":         "specific",
+					"targetIdentifier":   "#apm-alerts",
+					"inputChannelId":     "C0XXXFKLXXX",
+					"integrationId":      float64(111),
+					"sentryAppId":        interface{}(nil),
+					"dateCreated":        "2022-04-15T15:06:01.087054Z",
+					"desc":               "Send a Slack notification to #apm-alerts",
+				},
+				},
+			},
+		},
+		Projects: []string{"pump-station"},
+		Owner:    "pump-station:12345",
+		Created:  mustParseTime("2022-04-15T15:06:01.05618Z"),
+	}
+
+	require.Equal(t, expected, apmRule)
+}
+
+func TestAPMRuleService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	environment := "production"
+	params := &APMRule{
+		ID:               "12345",
+		Name:             "pump-station-alert",
+		Environment:      &environment,
+		DataSet:          "transactions",
+		Query:            "http.url:http://service/unreadmessages",
+		Aggregate:        "p50(transaction.duration)",
+		TimeWindow:       10,
+		ThresholdType:    0,
+		ResolveThreshold: 0,
+		Triggers: []Trigger{{
+			"actions":          []interface{}{map[string]interface{}{}},
+			"alertRuleId":      "12345",
+			"alertThreshold":   10000,
+			"dateCreated":      "2022-04-15T15:06:01.079598Z",
+			"id":               "56789",
+			"label":            "critical",
+			"resolveThreshold": 0,
+			"thresholdType":    0,
+		}},
+		Owner:   "pump-station:12345",
+		Created: mustParseTime("2022-04-15T15:06:01.079598Z"),
+	}
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/alert-rules/12345/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PUT", r)
+		assertPostJSON(t, map[string]interface{}{
+			"id":               "12345",
+			"name":             "pump-station-alert",
+			"environment":      environment,
+			"dataset":          "transactions",
+			"query":            "http.url:http://service/unreadmessages",
+			"aggregate":        "p50(transaction.duration)",
+			"timeWindow":       json.Number("10"),
+			"thresholdType":    json.Number("0"),
+			"resolveThreshold": json.Number("0"),
+			"triggers": []interface{}{
+				map[string]interface{}{
+					"actions":          []interface{}{map[string]interface{}{}},
+					"alertRuleId":      "12345",
+					"alertThreshold":   json.Number("10000"),
+					"dateCreated":      "2022-04-15T15:06:01.079598Z",
+					"id":               "56789",
+					"label":            "critical",
+					"resolveThreshold": json.Number("0"),
+					"thresholdType":    json.Number("0"),
+				},
+			},
+			"projects":    interface{}(nil),
+			"owner":       "pump-station:12345",
+			"dateCreated": "2022-04-15T15:06:01.079598Z",
+		}, r)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `
+			{
+				"id": "12345",
+				"name": "pump-station-alert",
+				"environment": "production",
+				"dataset": "transactions",
+				"query": "http.url:http://service/unreadmessages",
+				"aggregate": "p50(transaction.duration)",
+				"timeWindow": 10,
+				"thresholdType": 0,
+				"resolveThreshold": 0,
+				"triggers": [
+				  {
+					"actions": [
+						{
+							"id":                 "12389",
+							"alertRuleTriggerId": "56789",
+							"type":               "slack",
+							"targetType":         "specific",
+							"targetIdentifier":   "#apm-alerts",
+							"inputChannelId":     "C0XXXFKLXXX",
+							"integrationId":      111,
+							"sentryAppId":        null,
+							"dateCreated":        "2022-04-15T15:06:01.087054Z",
+							"desc":               "Send a Slack notification to #apm-alerts"
+						}
+					],
+					"alertRuleId": "12345",
+					"alertThreshold": 10000,
+					"dateCreated": "2022-04-15T15:06:01.079598Z",
+					"id": "56789",
+					"label": "critical",
+					"resolveThreshold": 0,
+					"thresholdType": 0
+				  }
+				],
+				"projects": [
+				  "pump-station"
+				],
+				"owner": "pump-station:12345",
+				"dateCreated": "2022-04-15T15:06:01.05618Z"
+			}
+		`)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	apmRule, _, err := client.APMRules.Update("the-interstellar-jurisdiction", "pump-station", "12345", params)
+	assert.NoError(t, err)
+
+	expected := &APMRule{
+		ID:               "12345",
+		Name:             "pump-station-alert",
+		Environment:      &environment,
+		DataSet:          "transactions",
+		Query:            "http.url:http://service/unreadmessages",
+		Aggregate:        "p50(transaction.duration)",
+		ThresholdType:    int(0),
+		ResolveThreshold: float64(0),
+		TimeWindow:       float64(10.0),
+		Triggers: []Trigger{
+			{
+				"id":               "56789",
+				"alertRuleId":      "12345",
+				"label":            "critical",
+				"thresholdType":    float64(0),
+				"alertThreshold":   float64(10000),
+				"resolveThreshold": float64(0),
+				"dateCreated":      "2022-04-15T15:06:01.079598Z",
+				"actions": []interface{}{map[string]interface{}{
+					"id":                 "12389",
+					"alertRuleTriggerId": "56789",
+					"type":               "slack",
+					"targetType":         "specific",
+					"targetIdentifier":   "#apm-alerts",
+					"inputChannelId":     "C0XXXFKLXXX",
+					"integrationId":      float64(111),
+					"sentryAppId":        interface{}(nil),
+					"dateCreated":        "2022-04-15T15:06:01.087054Z",
+					"desc":               "Send a Slack notification to #apm-alerts",
+				}},
+			},
+		},
+		Projects: []string{"pump-station"},
+		Owner:    "pump-station:12345",
+		Created:  mustParseTime("2022-04-15T15:06:01.05618Z"),
+	}
+
+	require.Equal(t, expected, apmRule)
+}
+
+func TestAPMRuleService_Delete(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/alert-rules/12345/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+	})
+
+	client := NewClient(httpClient, nil, "")
+	_, err := client.APMRules.Delete("the-interstellar-jurisdiction", "pump-station", "12345")
+	require.NoError(t, err)
+}

--- a/sentry/sentry.go
+++ b/sentry/sentry.go
@@ -24,6 +24,7 @@ type Client struct {
 	ProjectKeys         *ProjectKeyService
 	ProjectPlugins      *ProjectPluginService
 	Rules               *RuleService
+	APMRules            *APMRuleService
 	Ownership           *ProjectOwnershipService
 }
 
@@ -55,6 +56,7 @@ func NewClient(httpClient *http.Client, baseURL *url.URL, token string) *Client 
 		ProjectKeys:         newProjectKeyService(base.New()),
 		ProjectPlugins:      newProjectPluginService(base.New()),
 		Rules:               newRuleService(base.New()),
+		APMRules:            newAPMRuleService(base.New()),
 		Ownership:           newProjectOwnershipService(base.New()),
 	}
 	return c


### PR DESCRIPTION
The current `RuleService` only allows for creating alerts based on error conditions. This PR adds functionality to create APM alerts via the client, so you can do things like the screenshot below where you configure an alert based on transaction duration.

> I would like to use this functionality to extend the terraform provider https://github.com/jianyuan/terraform-provider-sentry to allow it to also configure APM type alerts.

![image](https://user-images.githubusercontent.com/92871444/163660947-029ae698-3a21-4e37-8366-5d54ed8f6428.png)
