### PR TITLE
Custom decode errors for unhandled error types

### DIFF
--- a/sentry/errors_test.go
+++ b/sentry/errors_test.go
@@ -1,0 +1,48 @@
+package sentry
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestAPIErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		have    string
+		want    string
+		wantErr bool
+	}{{
+		name: "detail",
+		have: `{"detail": "description"}`,
+		want: "sentry: description",
+	}, {
+		name: "detail+others",
+		have: `{"detail": "description", "other": "field"}`,
+		want: "sentry: map[detail:description other:field]",
+	}, {
+		name: "jsonstring",
+		have: `"jsonstring"`,
+		want: "sentry: jsonstring",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// https://github.com/dghubble/sling/blob/master/sling.go#L412
+			decoder := json.NewDecoder(strings.NewReader(tt.have))
+
+			var e APIError
+			err := decoder.Decode(&e)
+			if err != nil {
+				if !tt.wantErr {
+					t.Fatal(err)
+				}
+				return
+			}
+			got := e.Error()
+			if tt.want != got {
+				t.Errorf("want %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently terraform is failing with the following error response:
```
Error: json: cannot unmarshal string into Go value of type sentry.APIError
```
Believe this is due to a rate limit error. To support different error
types this decodes the value to an interface which is typed switch for
pretty printing the error response.