### PR TITLE
fix: use string array for scopes type

### DIFF
--- a/sentry/organization_integrations.go
+++ b/sentry/organization_integrations.go
@@ -25,7 +25,7 @@ type OrganizationIntegration struct {
 	Icon        string                          `json:"icon"`
 	DomainName  string                          `json:"domainName"`
 	AccountType string                          `json:"accountType"`
-	Scopes      *[]string                       `json:"scopes"`
+	Scopes      []string                       `json:"scopes"`
 	Status      string                          `json:"status"`
 	Provider    OrganizationIntegrationProvider `json:"provider"`
 

--- a/sentry/organization_integrations.go
+++ b/sentry/organization_integrations.go
@@ -25,7 +25,7 @@ type OrganizationIntegration struct {
 	Icon        string                          `json:"icon"`
 	DomainName  string                          `json:"domainName"`
 	AccountType string                          `json:"accountType"`
-	Scopes      *string                         `json:"scopes"`
+	Scopes      *[]string                       `json:"scopes"`
 	Status      string                          `json:"status"`
 	Provider    OrganizationIntegrationProvider `json:"provider"`
 

--- a/sentry/organization_integrations_test.go
+++ b/sentry/organization_integrations_test.go
@@ -65,7 +65,7 @@ func TestOrganizationIntegrationsService_List(t *testing.T) {
 			Icon:        "https://avatars.githubusercontent.com/u/583231?v=4",
 			DomainName:  "github.com/octocat",
 			AccountType: "Organization",
-			Scopes:      &[]string{"read", "write"},
+			Scopes:      []string{"read", "write"},
 			Status:      "active",
 			Provider: OrganizationIntegrationProvider{
 				Key:        "github",

--- a/sentry/organization_integrations_test.go
+++ b/sentry/organization_integrations_test.go
@@ -24,7 +24,7 @@ func TestOrganizationIntegrationsService_List(t *testing.T) {
 				"icon": "https://avatars.githubusercontent.com/u/583231?v=4",
 				"domainName": "github.com/octocat",
 				"accountType": "Organization",
-				"scopes": null,
+				"scopes": ["read", "write"],
 				"status": "active",
 				"provider": {
 					"key": "github",
@@ -65,7 +65,7 @@ func TestOrganizationIntegrationsService_List(t *testing.T) {
 			Icon:        "https://avatars.githubusercontent.com/u/583231?v=4",
 			DomainName:  "github.com/octocat",
 			AccountType: "Organization",
-			Scopes:      nil,
+			Scopes:      &[]string{"read", "write"},
 			Status:      "active",
 			Provider: OrganizationIntegrationProvider{
 				Key:        "github",


### PR DESCRIPTION
# Intent

Minor fix: Sentry Integrations use an array of scopes, not a string literal.