### PR TITLE
fix: add support for default_rules to create project

### DIFF
--- a/sentry/projects.go
+++ b/sentry/projects.go
@@ -128,9 +128,10 @@ func (s *ProjectsService) Get(ctx context.Context, organizationSlug string, slug
 
 // CreateProjectParams are the parameters for ProjectService.Create.
 type CreateProjectParams struct {
-	Name     string `json:"name,omitempty"`
-	Slug     string `json:"slug,omitempty"`
-	Platform string `json:"platform,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Slug         string `json:"slug,omitempty"`
+	Platform     string `json:"platform,omitempty"`
+	DefaultRules *bool  `json:"default_rules,omitempty"`
 }
 
 // Create a new project bound to a team.


### PR DESCRIPTION
Simply adds support for the `default_rules` parameter as described [in the docs](https://docs.sentry.io/api/projects/create-a-new-project/).

Not sure how to add a test for this as the API doesn't return anything different based on the input, open to suggestions though.