### PR TITLE
Adds ComparisonDelta prop to MetricAlert

### DIFF
--- a/sentry/metric_alerts.go
+++ b/sentry/metric_alerts.go
@@ -20,6 +20,7 @@ type MetricAlert struct {
 	TimeWindow       *float64              `json:"timeWindow,omitempty"`
 	ThresholdType    *int                  `json:"thresholdType,omitempty"`
 	ResolveThreshold *float64              `json:"resolveThreshold,omitempty"`
+	ComparisonDelta  *float64              `json:"comparisonDelta,omitempty"`
 	Triggers         []*MetricAlertTrigger `json:"triggers,omitempty"`
 	Projects         []string              `json:"projects,omitempty"`
 	Owner            *string               `json:"owner,omitempty"`


### PR DESCRIPTION
https://docs.sentry.io/api/alerts/create-a-metric-alert-rule-for-an-organization/

```
comparisonDelta (integer)

An optional int representing the time delta to use as the comparison period, in minutes. Required when using a percentage change threshold ("x%" higher or lower compared to comparisonDelta minutes ago). A percentage change threshold cannot be used for Crash Free Session Rate or Crash Free User Rate.
```