### PR TITLE
Update dashboard api

### DIFF
--- a/sentry/dashboards.go
+++ b/sentry/dashboards.go
@@ -6,12 +6,25 @@ import (
 	"time"
 )
 
+// Permission represents a dashboard permissions.
+type Permission struct {
+	IsEditableByEveryone *bool  `json:"isEditableByEveryone,omitempty"`
+	TeamsWithEditAccess  []*int `json:"teamsWithEditAccess,omitempty"`
+}
+
 // Dashboard represents a Dashboard.
 type Dashboard struct {
-	ID          *string            `json:"id,omitempty"`
-	Title       *string            `json:"title,omitempty"`
-	DateCreated *time.Time         `json:"dateCreated,omitempty"`
-	Widgets     []*DashboardWidget `json:"widgets,omitempty"`
+	ID           *string            `json:"id,omitempty"`
+	Title        *string            `json:"title,omitempty"`
+	DateCreated  *time.Time         `json:"dateCreated,omitempty"`
+	Widgets      []*DashboardWidget `json:"widgets,omitempty"`
+	Projects     []*int             `json:"projects,omitempty"`
+	Environments []*string          `json:"environments,omitempty"`
+	Period       *string            `json:"period,omitempty"`
+	Start        *string            `json:"start,omitempty"`
+	End          *string            `json:"end,omitempty"`
+	Permissions  *Permission        `json:"permissions,omitempty"`
+	IsFavorited  *bool              `json:"is_favorited,omitempty"`
 }
 
 // DashboardsService provides methods for accessing Sentry dashboard API endpoints.

--- a/sentry/dashboards_test.go
+++ b/sentry/dashboards_test.go
@@ -2,6 +2,7 @@ package sentry
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -146,8 +147,13 @@ func TestDashboardsService_Create(t *testing.T) {
 	mux.HandleFunc("/api/0/organizations/the-interstellar-jurisdiction/dashboards/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "POST", r)
 		assertPostJSONValue(t, map[string]interface{}{
-			"title":   "General",
-			"widgets": map[string]interface{}{},
+			"title": "General",
+			"permissions": map[string]interface{}{
+				"isEditableByEveryone": true,
+				"teamsWithEditAccess":  []interface{}{json.Number("3"), json.Number("4")},
+			},
+			"projects": []interface{}{json.Number("1"), json.Number("2")},
+			"period":   "14d",
 		}, r)
 
 		w.Header().Set("Content-Type", "application/json")
@@ -155,13 +161,25 @@ func TestDashboardsService_Create(t *testing.T) {
 			"id": "12072",
 			"title": "General",
 			"dateCreated": "2022-06-07T16:48:26.255520Z",
-			"widgets": []
+			"widgets": [],
+            "permissions": {
+                "isEditableByEveryone": true,
+                "teamsWithEditAccess": [3, 4]
+            },
+            "projects": [1, 2],
+            "period": "14d"
 		}`)
 	})
 
 	params := &Dashboard{
 		Title:   String("General"),
 		Widgets: []*DashboardWidget{},
+		Permissions: &Permission{
+			IsEditableByEveryone: Bool(true),
+			TeamsWithEditAccess:  []*int{Int(3), Int(4)},
+		},
+		Projects: []*int{Int(1), Int(2)},
+		Period:   String("14d"),
 	}
 	ctx := context.Background()
 	dashboard, _, err := client.Dashboards.Create(ctx, "the-interstellar-jurisdiction", params)
@@ -171,6 +189,12 @@ func TestDashboardsService_Create(t *testing.T) {
 		Title:       String("General"),
 		DateCreated: Time(mustParseTime("2022-06-07T16:48:26.255520Z")),
 		Widgets:     []*DashboardWidget{},
+		Projects:    []*int{Int(1), Int(2)},
+		Permissions: &Permission{
+			IsEditableByEveryone: Bool(true),
+			TeamsWithEditAccess:  []*int{Int(3), Int(4)},
+		},
+		Period: String("14d"),
 	}
 	assert.Equal(t, expected, dashboard)
 	assert.NoError(t, err)
@@ -183,9 +207,10 @@ func TestDashboardsService_Update(t *testing.T) {
 	mux.HandleFunc("/api/0/organizations/the-interstellar-jurisdiction/dashboards/12072/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "PUT", r)
 		assertPostJSONValue(t, map[string]interface{}{
-			"id":      "12072",
-			"title":   "General",
-			"widgets": map[string]interface{}{},
+			"id":       "12072",
+			"title":    "General",
+			"projects": []interface{}{json.Number("1"), json.Number("2")},
+			"period":   "14d",
 		}, r)
 
 		w.Header().Set("Content-Type", "application/json")
@@ -193,14 +218,18 @@ func TestDashboardsService_Update(t *testing.T) {
 			"id": "12072",
 			"title": "General",
 			"dateCreated": "2022-06-07T16:48:26.255520Z",
-			"widgets": []
+			"widgets": [],
+            "projects": [1, 2],
+            "period": "14d"
 		}`)
 	})
 
 	params := &Dashboard{
-		ID:      String("12072"),
-		Title:   String("General"),
-		Widgets: []*DashboardWidget{},
+		ID:       String("12072"),
+		Title:    String("General"),
+		Widgets:  []*DashboardWidget{},
+		Projects: []*int{Int(1), Int(2)},
+		Period:   String("14d"),
 	}
 	ctx := context.Background()
 	dashboard, _, err := client.Dashboards.Update(ctx, "the-interstellar-jurisdiction", "12072", params)
@@ -210,6 +239,8 @@ func TestDashboardsService_Update(t *testing.T) {
 		Title:       String("General"),
 		DateCreated: Time(mustParseTime("2022-06-07T16:48:26.255520Z")),
 		Widgets:     []*DashboardWidget{},
+		Projects:    []*int{Int(1), Int(2)},
+		Period:      String("14d"),
 	}
 	assert.Equal(t, expected, dashboard)
 	assert.NoError(t, err)

--- a/sentry/issue_alerts_test.go
+++ b/sentry/issue_alerts_test.go
@@ -350,18 +350,18 @@ func TestIssueAlertsService_Create(t *testing.T) {
 		assertPostJSONValue(t, map[string]interface{}{
 			"actionMatch": "all",
 			"environment": "production",
-			"frequency":   30,
+			"frequency":   json.Number("30"),
 			"name":        "Notify errors",
-			"conditions": []map[string]interface{}{
-				{
+			"conditions": []interface{}{
+				map[string]interface{}{
 					"interval": "1h",
 					"name":     "The issue is seen more than 10 times in 1h",
-					"value":    10,
+					"value":    json.Number("10"),
 					"id":       "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
 				},
 			},
-			"actions": []map[string]interface{}{
-				{
+			"actions": []interface{}{
+				map[string]interface{}{
 					"id":         "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
 					"name":       "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
 					"tags":       "environment",
@@ -501,18 +501,18 @@ func TestIssueAlertsService_CreateWithAsyncTask(t *testing.T) {
 		assertPostJSONValue(t, map[string]interface{}{
 			"actionMatch": "all",
 			"environment": "production",
-			"frequency":   30,
+			"frequency":   json.Number("30"),
 			"name":        "Notify errors",
-			"conditions": []map[string]interface{}{
-				{
+			"conditions": []interface{}{
+				map[string]interface{}{
 					"interval": "1h",
 					"name":     "The issue is seen more than 10 times in 1h",
-					"value":    10,
+					"value":    json.Number("10"),
 					"id":       "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
 				},
 			},
-			"actions": []map[string]interface{}{
-				{
+			"actions": []interface{}{
+				map[string]interface{}{
 					"id":         "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
 					"name":       "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
 					"tags":       "environment",
@@ -642,15 +642,15 @@ func TestIssueAlertsService_Update(t *testing.T) {
 			"frequency":   json.Number("30"),
 			"name":        "Notify errors",
 			"dateCreated": "2019-08-24T18:12:16.321Z",
-			"conditions": []map[string]interface{}{
-				{
+			"conditions": []interface{}{
+				map[string]interface{}{
 					"id":       "sentry.rules.conditions.event_frequency.EventFrequencyCondition",
 					"value":    json.Number("500"),
 					"interval": "1h",
 				},
 			},
-			"actions": []map[string]interface{}{
-				{
+			"actions": []interface{}{
+				map[string]interface{}{
 					"id":         "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
 					"name":       "Send a notification to the Dummy Slack workspace to #dummy-channel and show tags [environment] in notification",
 					"tags":       "environment",
@@ -659,13 +659,13 @@ func TestIssueAlertsService_Update(t *testing.T) {
 					"workspace":  "1234",
 				},
 			},
-			"filters": []map[string]interface{}{
-				{
+			"filters": []interface{}{
+				map[string]interface{}{
 					"id":    "sentry.rules.filters.issue_occurrences.IssueOccurrencesFilter",
 					"name":  "The issue has happened at least 4 times",
 					"value": json.Number("4"),
 				},
-				{
+				map[string]interface{}{
 					"attribute": "message",
 					"id":        "sentry.rules.filters.event_attribute.EventAttributeFilter",
 					"match":     "eq",

--- a/sentry/metric_alerts_test.go
+++ b/sentry/metric_alerts_test.go
@@ -270,44 +270,41 @@ func TestMetricAlertsService_CreateWithAsyncTask(t *testing.T) {
 	mux.HandleFunc("/api/0/projects/the-interstellar-jurisdiction/pump-station/alert-rules/", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "POST", r)
 		assertPostJSONValue(t, map[string]interface{}{
-			"id":               "12345",
 			"name":             "pump-station-alert",
 			"environment":      "production",
 			"dataset":          "transactions",
-			"eventTypes":       []string{"transaction"},
+			"eventTypes":       []interface{}{"transaction"},
 			"query":            "http.url:http://service/unreadmessages",
 			"aggregate":        "p50(transaction.duration)",
-			"timeWindow":       10,
-			"thresholdType":    0,
-			"resolveThreshold": 0,
-			"triggers": []map[string]interface{}{
-				{
-					"actions": []map[string]interface{}{
-						{
+			"timeWindow":       json.Number("10"),
+			"thresholdType":    json.Number("0"),
+			"resolveThreshold": json.Number("0"),
+			"triggers": []interface{}{
+				map[string]interface{}{
+					"actions": []interface{}{
+						map[string]interface{}{
 							"alertRuleTriggerId": "56789",
 							"dateCreated":        "2022-04-15T15:06:01.087054Z",
 							"desc":               "Send a Slack notification to #alert-rule-alerts",
 							"id":                 "12389",
 							"inputChannelId":     "C0XXXFKLXXX",
-							"integrationId":      111,
-							"sentryAppId":        nil,
+							"integrationId":      json.Number("123"),
 							"targetIdentifier":   "#alert-rule-alerts",
 							"targetType":         "specific",
 							"type":               "slack",
 						},
 					},
 					"alertRuleId":      "12345",
-					"alertThreshold":   10000,
+					"alertThreshold":   json.Number("55501"),
 					"dateCreated":      "2022-04-15T15:06:01.079598Z",
 					"id":               "56789",
 					"label":            "critical",
-					"resolveThreshold": 0,
-					"thresholdType":    0,
+					"resolveThreshold": json.Number("100"),
+					"thresholdType":    json.Number("0"),
 				},
 			},
-			"projects":    []string{"pump-station"},
-			"owner":       "pump-station:12345",
-			"dateCreated": "2022-04-15T15:06:01.05618Z",
+			"projects": []interface{}{"pump-station"},
+			"owner":    "pump-station:12345",
 		}, r)
 
 		w.WriteHeader(http.StatusAccepted)
@@ -324,6 +321,7 @@ func TestMetricAlertsService_CreateWithAsyncTask(t *testing.T) {
 		TimeWindow:       Float64(10.0),
 		ThresholdType:    Int(0),
 		ResolveThreshold: Float64(0),
+		EventTypes:       []string{"transaction"},
 		Triggers: []*MetricAlertTrigger{
 			{
 				ID:               String("56789"),

--- a/sentry/sentry_test.go
+++ b/sentry/sentry_test.go
@@ -75,7 +75,7 @@ func assertPostJSONValue(t *testing.T, expected interface{}, req *http.Request) 
 
 	err := d.Decode(&actual)
 	assert.NoError(t, err)
-	assert.ObjectsAreEqualValues(expected, actual)
+	assert.EqualValues(t, expected, actual)
 }
 
 func mustParseTime(value string) time.Time {


### PR DESCRIPTION
## Description

Add new keys for dashboard entity:
- projects
- environments
- period
- start
- end
- permissions
    - isEditableByEveryone
    - teamsWithEditAccess
- is_favorited

based on sentry API documentation: https://docs.sentry.io/api/dashboards/create-a-new-dashboard-for-an-organization/

## How

After adding the new values in the dashboard params, I think I found a bug in the `assetPostJSONValue` which was not testing the expected JSON value (more details in this commit d6631b4069179f86889ebba9d126500709a1716e), let me know if I miss understood something here 🙏 